### PR TITLE
Made refresh button rotate while repositories are loading to be viewed

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -80,6 +80,7 @@ export function App() {
       <Navigation
         onSettingsClick={() => setShowSettings(true)}
         onRefreshClick={refresh}
+        dataLoading={isFetchingMore || isLoading || isRefetching}
       />
 
       {!isOnline ? (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -80,7 +80,7 @@ export function App() {
       <Navigation
         onSettingsClick={() => setShowSettings(true)}
         onRefreshClick={refresh}
-        dataLoading={isFetchingMore || isLoading || isRefetching}
+        isDataLoading={isFetchingMore || isLoading || isRefetching}
       />
 
       {!isOnline ? (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,13 +1,14 @@
-import { RefreshCcw, Settings } from 'lucide-react';
+import { RefreshCw, Settings } from 'lucide-react';
 import { Logo } from './Logo';
 
 interface NavigationProps {
   onSettingsClick: () => void;
   onRefreshClick: () => void;
+  dataLoading: boolean;
 }
 
 export function Navigation(props: NavigationProps) {
-  const { onSettingsClick, onRefreshClick } = props;
+  const { onSettingsClick, onRefreshClick, dataLoading } = props;
 
   return (
     <nav className='px-4 sm:px-6 py-4 flex justify-between flex-row bg-white/5 backdrop-blur-xl border-b border-white/10 z-50'>
@@ -31,7 +32,7 @@ export function Navigation(props: NavigationProps) {
             onClick={onRefreshClick}
             className='p-2 text-white/70 hover:text-white transition-colors'
           >
-            <RefreshCcw className='w-5 h-5' />
+            <RefreshCw className={`w-5 h-5 ${dataLoading ? 'animate-spin' : ''}`} />
           </button>
         </div>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,11 +4,11 @@ import { Logo } from './Logo';
 interface NavigationProps {
   onSettingsClick: () => void;
   onRefreshClick: () => void;
-  dataLoading: boolean;
+  isDataLoading: boolean;
 }
 
 export function Navigation(props: NavigationProps) {
-  const { onSettingsClick, onRefreshClick, dataLoading } = props;
+  const { onSettingsClick, onRefreshClick, isDataLoading } = props;
 
   return (
     <nav className='px-4 sm:px-6 py-4 flex justify-between flex-row bg-white/5 backdrop-blur-xl border-b border-white/10 z-50'>
@@ -31,9 +31,9 @@ export function Navigation(props: NavigationProps) {
           <button
             onClick={onRefreshClick}
             className='p-2 text-white/70 hover:text-white transition-colors'
-            disabled={dataLoading}
+            disabled={isDataLoading}
           >
-            <RefreshCw className={`w-5 h-5 ${dataLoading ? 'animate-spin' : ''}`} />
+            <RefreshCw className={`w-5 h-5 ${isDataLoading ? 'animate-spin' : ''}`} />
           </button>
         </div>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -31,6 +31,7 @@ export function Navigation(props: NavigationProps) {
           <button
             onClick={onRefreshClick}
             className='p-2 text-white/70 hover:text-white transition-colors'
+            disabled={dataLoading}
           >
             <RefreshCw className={`w-5 h-5 ${dataLoading ? 'animate-spin' : ''}`} />
           </button>


### PR DESCRIPTION
This PR is the solution for #4 

Used `RefreshCw` component instead of `RefreshCcw` from `lucide-react` for two reasons 
- Reason 1: This follows common UI conventions seen in browsers, apps, and operating systems 
- Reason 2: Tailwind Css's `animate-spin` naturally rotates clockwise and using`RefreshCw` component supports this without additional changes.

**Result**
Now the refresh button rotates whenever repositories are loaded to be viewed

https://github.com/user-attachments/assets/b4d47319-c657-46b4-8dda-4b54efec85e8

Thank you for your time! 😄 
