### PR TITLE
Enhanced repository fetch to include subscribers_count

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,6 +18,7 @@ export function App() {
   const [selectedFeedType, setSelectedFeedType] = useState<FeedType>('random');
   const [isInitialized, setIsInitialized] = useState(false);
   const isOnline = useOnlineStatus();
+  const isTokenSaved = !!selectedToken;
 
   useEffect(() => {
     const savedLanguage = localStorage.getItem('preferred_language');
@@ -105,6 +106,7 @@ export function App() {
         <RepositoryList
           repositories={repositories}
           scrollContainerRef={scrollContainerRef}
+          tokenStatus={{isTokenSaved}}
         />
       )}
     </div>

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -37,7 +37,7 @@ export type Repository = {
   created_at: string;
   updated_at: string;
   stargazers_count: number;
-  watchers_count: number;
+  subscribers_count: number;
   language: string;
   forks_count: number;
   topics: string[];
@@ -46,11 +46,16 @@ export type Repository = {
   [key: string]: any;
 };
 
-interface RepositoryCardProps {
-  repository: Repository;
+export type TokenStatus = {
+  isTokenSaved: boolean;
 }
 
-export function RepositoryCard({ repository }: RepositoryCardProps) {
+interface RepositoryCardProps {
+  repository: Repository;
+  tokenStatus: TokenStatus;
+}
+
+export function RepositoryCard({ repository, tokenStatus }: RepositoryCardProps) {
   const getLanguageColor = () => {
     const colors: { [key: string]: string } = {
       JavaScript: 'bg-yellow-300/80',
@@ -147,7 +152,7 @@ export function RepositoryCard({ repository }: RepositoryCardProps) {
       </div>
 
       <div className='bg-gradient-to-r from-white/[0.03] to-white/[0.02] rounded-2xl p-3 backdrop-blur-xl border border-white/[0.06] shadow-xl'>
-        <div className='grid grid-cols-3 divide-x divide-white/[0.06]'>
+        <div className='grid grid-flow-col auto-cols-auto divide-x divide-white/[0.06]'>
           <div className='flex flex-col items-center justify-center p-2'>
             <Star className='w-4 h-4 text-white/50 mb-1' />
             <div className='text-xl font-medium text-white'>
@@ -168,15 +173,15 @@ export function RepositoryCard({ repository }: RepositoryCardProps) {
             </div>
           </div>
 
-          <div className='flex flex-col items-center justify-center p-2'>
+          {tokenStatus.isTokenSaved && <div className='flex flex-col items-center justify-center p-2'>
             <GitPullRequest className='w-4 h-4 text-white/50 mb-1' />
             <div className='text-xl font-medium text-white'>
-              {shortNumber(repository.watchers_count)}
+              {shortNumber(repository.subscribers_count)}
             </div>
             <div className='text-[0.65rem] text-white/40 font-medium uppercase tracking-wider'>
               Watchers
             </div>
-          </div>
+          </div>}
         </div>
       </div>
 

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,13 +1,14 @@
 import { RefObject } from 'react';
-import { Repository, RepositoryCard } from './RepositoryCard';
+import { Repository, RepositoryCard, TokenStatus } from './RepositoryCard';
 
 interface RepositoryListProps {
   repositories: Repository[];
   scrollContainerRef: RefObject<HTMLDivElement | null>;
+  tokenStatus: TokenStatus;
 }
 
 export function RepositoryList(props: RepositoryListProps) {
-  const { repositories, scrollContainerRef } = props;
+  const { repositories, scrollContainerRef, tokenStatus } = props;
 
   return (
     <div
@@ -20,7 +21,7 @@ export function RepositoryList(props: RepositoryListProps) {
           className='snap-start min-h-[calc(100dvh-60px)] h-[calc(100dvh-60px)] flex items-center py-6'
         >
           <div className='w-full max-w-3xl mx-auto px-4 sm:px-6 h-full'>
-            <RepositoryCard repository={repository} />
+            <RepositoryCard repository={repository} tokenStatus={tokenStatus} />
           </div>
         </div>
       ))}


### PR DESCRIPTION
Fixes #8 

- Added functionality to fetch the `subscribers_count` for each repository returned by the search API.
- _repo.url_ in line _125_ of `github.ts` is in the format _https://api.github.com/repos/{owner}/{repo}_
- This request has a **non-token rate limit** of _60/Hr_ and a **token-included rate limit** of _5000/Hr_
- Thus `subscribers_count` is only fetched and displayed if user has saved a Github token.
- Implemented concurrent API calls using `Promise.all` to fetch additional repository details without blocking.
- Improved error handling: If fetching detailed repository data fails, `subscribers_count` will default to `null` instead of breaking the process.

**Result:**

https://github.com/user-attachments/assets/0e20f7c9-e7e9-4d07-a9e1-f6b2500673a8

Felt pretty good working on this bug 👼 